### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,9 +1,9 @@
 name: Ruby
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
-  validate_openapi:
+  test:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Renames "validate_openapi" to "test" as this was a copy/paste error that
stuck around when setting up the CI.

Also I noticed that were were
runnining the CI 2 times when opening up a merge request because it was
triggered on `pull_request` and `push` events. This reduces it to just
the `push` event so the CI doesn't run 2 times when opening up a pull
request.