### PR TITLE
Support non-paginated list endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 *.gem
 *.swp
-.DS_Store
 .bundle
 .config
+.DS_Store
+.idea
 .ruby-*
 .rvmrc
 .yardoc
-.idea
-Gemfile.lock
 coverage
+Gemfile.lock
 pkg/*
 tmp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,14 +3,17 @@ AllCops:
   SuggestExtensions: false # Disabling extension suggestions
   TargetRubyVersion: 2.6
 
+Layout/LineLength:
+  Description: Checks the length of lines in the source code
+  Exclude:
+    - 'spec/lib/**/*.rb' # Excluding to avoid multiline expect statements
+  IgnoredPatterns: ['^        endpoint: ".*'] # Excluding since the endpoints may require longer lines
+  Max: 120
+
 Metrics/AbcSize:
   Description: Checks that the ABC size of methods is not higher than the configured maximum
   Exclude:
     - 'lib/mx-platform-ruby/pageable.rb' # Disabling because clarity > brevity
-
-Metrics/MethodLength:
-  Description: Checks if the length a method exceeds some maximum value
-  Enabled: false # Disabling to allow class methods to grow with number of attributes
 
 Metrics/BlockLength:
   Description: Checks if the length of a block exceeds some maximum value
@@ -21,12 +24,9 @@ Metrics/ClassLength:
   Description: Checks if the length a class exceeds some maximum value
   Enabled: false # Disabling because clarity > brevity
 
-Layout/LineLength:
-  Description: Checks the length of lines in the source code
-  Exclude:
-    - 'spec/lib/**/*.rb' # Excluding to avoid multiline expect statements
-  IgnoredPatterns: ['^        endpoint: ".*'] # Excluding since the endpoints may requrie longer lines
-  Max: 120
+Metrics/MethodLength:
+  Description: Checks if the length a method exceeds some maximum value
+  Enabled: false # Disabling to allow class methods to grow with number of attributes
 
 Naming/FileName:
   Description: Checks that Ruby source files have snake_case names

--- a/lib/mx-platform-ruby/enhanced_transaction.rb
+++ b/lib/mx-platform-ruby/enhanced_transaction.rb
@@ -25,8 +25,7 @@ module MXPlatformRuby
       enhance_transactions_options = enhance_transactions_options(options)
       response = ::MXPlatformRuby.client.make_request(enhance_transactions_options)
 
-      transactions_params = response['transactions']
-      ::MXPlatformRuby::EnhancedTransaction.new(transactions_params)
+      response['transactions'].map { |attributes| ::MXPlatformRuby::EnhancedTransaction.new(attributes) }
     end
 
     # Private class methods

--- a/spec/lib/mx-platform-ruby/enhanced_transaction_spec.rb
+++ b/spec/lib/mx-platform-ruby/enhanced_transaction_spec.rb
@@ -38,29 +38,31 @@ RSpec.describe ::MXPlatformRuby::EnhancedTransaction do
   end
 
   describe 'enhance_transactions' do
-    let(:enhance_transactions_response) { { 'transactions' => enhanced_transaction_attributes } }
+    let(:enhance_transactions_response) { { 'transactions' => [enhanced_transaction_attributes] } }
     before { allow(::MXPlatformRuby.client).to receive(:make_request).and_return(enhance_transactions_response) }
 
-    it 'returns enhanced_transaction' do
+    it 'returns an array of enhanced_transactions' do
       response = described_class.enhance_transactions
 
-      expect(response).to be_kind_of(::MXPlatformRuby::EnhancedTransaction)
-      expect(response.amount).to eq(enhanced_transaction_attributes[:amount])
-      expect(response.category).to eq(enhanced_transaction_attributes[:category])
-      expect(response.description).to eq(enhanced_transaction_attributes[:description])
-      expect(response.id).to eq(enhanced_transaction_attributes[:id])
-      expect(response.is_bill_pay).to eq(enhanced_transaction_attributes[:is_bill_pay])
-      expect(response.is_direct_deposit).to eq(enhanced_transaction_attributes[:is_direct_deposit])
-      expect(response.is_expense).to eq(enhanced_transaction_attributes[:is_expense])
-      expect(response.is_fee).to eq(enhanced_transaction_attributes[:is_fee])
-      expect(response.is_income).to eq(enhanced_transaction_attributes[:is_income])
-      expect(response.is_international).to eq(enhanced_transaction_attributes[:is_international])
-      expect(response.is_overdraft_fee).to eq(enhanced_transaction_attributes[:is_overdraft_fee])
-      expect(response.is_payroll_advance).to eq(enhanced_transaction_attributes[:is_payroll_advance])
-      expect(response.merchant_category_code).to eq(enhanced_transaction_attributes[:merchant_category_code])
-      expect(response.merchant_guid).to eq(enhanced_transaction_attributes[:merchant_guid])
-      expect(response.original_description).to eq(enhanced_transaction_attributes[:original_description])
-      expect(response.type).to eq(enhanced_transaction_attributes[:type])
+      expect(response).to be_kind_of(::Array)
+      expect(response.first).to be_kind_of(::MXPlatformRuby::EnhancedTransaction)
+      expect(response.first.amount).to eq(enhanced_transaction_attributes[:amount])
+      expect(response.first.category).to eq(enhanced_transaction_attributes[:category])
+      expect(response.first.description).to eq(enhanced_transaction_attributes[:description])
+      expect(response.first.id).to eq(enhanced_transaction_attributes[:id])
+      expect(response.first.is_bill_pay).to eq(enhanced_transaction_attributes[:is_bill_pay])
+      expect(response.first.is_direct_deposit).to eq(enhanced_transaction_attributes[:is_direct_deposit])
+      expect(response.first.is_expense).to eq(enhanced_transaction_attributes[:is_expense])
+      expect(response.first.is_fee).to eq(enhanced_transaction_attributes[:is_fee])
+      expect(response.first.is_income).to eq(enhanced_transaction_attributes[:is_income])
+      expect(response.first.is_international).to eq(enhanced_transaction_attributes[:is_international])
+      expect(response.first.is_overdraft_fee).to eq(enhanced_transaction_attributes[:is_overdraft_fee])
+      expect(response.first.is_payroll_advance).to eq(enhanced_transaction_attributes[:is_payroll_advance])
+      expect(response.first.merchant_category_code).to eq(enhanced_transaction_attributes[:merchant_category_code])
+      expect(response.first.merchant_guid).to eq(enhanced_transaction_attributes[:merchant_guid])
+      expect(response.first.original_description).to eq(enhanced_transaction_attributes[:original_description])
+      expect(response.first.type).to eq(enhanced_transaction_attributes[:type])
+      expect(response.length).to eq(1)
     end
 
     it 'makes a client request with the expected params' do


### PR DESCRIPTION
Adds support for non-paginated list endpoints. Currently this only
affects the enhance transactions endpoint.

Also includes small updates to the .gitignore and .rubocop.yml files.