### PR TITLE
Gitignore openapi generator file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+.openapitools.json
 
 ## Specific to RubyMotion:
 .dat*

--- a/lib/mx-platform-ruby/version.rb
+++ b/lib/mx-platform-ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 5.3.1
 =end
 
 module MxPlatformRuby
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end


### PR DESCRIPTION
Adds the `.openapitools.json` file to the gitignore.