### PR TITLE
Update generate action

### DIFF
--- a/.github/clean.rb
+++ b/.github/clean.rb
@@ -3,7 +3,6 @@ require "fileutils"
 ALLOW_LIST = [
   ".git",
   ".github",
-  ".gitignore",
   ".openapi-generator-ignore",
   "LICENSE",
   "openapi"

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -18,20 +18,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+    - uses: actions/setup-node@v2
+    - uses: ruby/setup-ruby@v1
       with:
-        bundler-cache: true
         ruby-version: 3.1
     - name: Bump version
       id: bump_version
       run: echo "::set-output name=version::$(ruby .github/version.rb ${{ github.event.inputs.version_level }})"
     - name: Clean repo
       run: ruby .github/clean.rb
-    - uses: actions/setup-node@v2
-    - run: |
+    - name: Install openapi-generator-cli
+      run: |
         npm install @openapitools/openapi-generator-cli -g
-        openapi-generator-cli version
+        openapi-generator-cli version-manager set 5.3.1
     - run: |
         openapi-generator-cli generate \
           -i https://raw.githubusercontent.com/mxenabled/openapi/master/openapi/mx_platform_api_beta.yml \

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
-.openapitools.json
 
 ## Specific to RubyMotion:
 .dat*

--- a/openapi/config.yml
+++ b/openapi/config.yml
@@ -1,11 +1,10 @@
----
-gemAuthor: "MX"
-gemAuthorEmail: "devexperience@mx.com"
-gemDescription: "A Ruby library for the MX Platform API."
-gemHomepage: "https://github.com/mxenabled/mx-platform-ruby"
-gemLicense: "MIT"
-gemName: "mx-platform-ruby"
+gemAuthor: MX
+gemAuthorEmail: devexperience@mx.com
+gemDescription: A Ruby library for the MX Platform API.
+gemHomepage: https://github.com/mxenabled/mx-platform-ruby
+gemLicense: MIT
+gemName: mx-platform-ruby
 gemRequiredRubyVersion: ">= 2.6"
-gemVersion: "0.8.2"
-library: "faraday"
-moduleName: "MxPlatformRuby"
+gemVersion: 0.8.2
+library: faraday
+moduleName: MxPlatformRuby


### PR DESCRIPTION
Updates the generate action to use a specific version of the npm
`openapi-generator-cli` tool. Removes `openapitools.json` from
.gitignore. Also includes small refactor/cleanup.