### PR TITLE
Allow file

### DIFF
--- a/.github/clean.rb
+++ b/.github/clean.rb
@@ -5,7 +5,8 @@ ALLOW_LIST = [
   ".github",
   ".openapi-generator-ignore",
   "LICENSE",
-  "openapi"
+  "openapi",
+  "openapitools.json"
 ].freeze
 
 ::Dir.each_child(::Dir.pwd) do |source|


### PR DESCRIPTION
Adds the `openapitools.json` file to the allowlist as recommended
by the `openapi-generator-cli` README.