### PR TITLE
bump openapitools generator version

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -2,6 +2,6 @@
   "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.0.1"
+    "version": "7.8.0"
   }
 }


### PR DESCRIPTION
Related to https://github.com/mxenabled/mx-platform-ruby/issues/90

Upgrade to latest OpenAPITools generator version.